### PR TITLE
Bump SDK version to 0.55.0 + minor updates

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-binary "https://github.com/paypal/paypalcheckout-ios/raw/main/Carthage/PayPalCheckout.json" ~> 0.44.0
+binary "https://github.com/paypal/paypalcheckout-ios/raw/main/Carthage/PayPalCheckout.json" ~> 0.55.0

--- a/Podfile
+++ b/Podfile
@@ -2,7 +2,7 @@ workspace 'Samples.xcworkspace'
 use_frameworks!
 
 def dependency
-  pod 'PayPalCheckout', '0.44.0'
+  pod 'PayPalCheckout', '0.55.0'
 end
 
 target 'Samples.ObjC' do

--- a/Samples.Swift/Samples.Swift/ViewControllers/CheckoutViewController/CheckoutViewController.swift
+++ b/Samples.Swift/Samples.Swift/ViewControllers/CheckoutViewController/CheckoutViewController.swift
@@ -338,7 +338,7 @@ class CheckoutViewController: UIViewController, AddItemViewControllerDelegate {
 
   func getItemTotal() -> String {
     let total = items.reduce(0) { (runningTotal, item) -> Double in
-       let unitAmount = Double(item.unitAmount.value) ?? 0
+       let unitAmount = Double(item.unitAmount.value ?? "0") ?? 0
        let quantity = Double(item.quantity) ?? 0
        return runningTotal + (quantity * unitAmount)
      }
@@ -348,7 +348,7 @@ class CheckoutViewController: UIViewController, AddItemViewControllerDelegate {
 
   func getTaxTotal() -> String {
     let total = items.reduce(0) { (runningTotal, item) -> Double in
-      let taxPrice = Double(item.tax!.value) ?? 0
+      let taxPrice = Double(item.tax?.value ?? "0") ?? 0
       let quantity = Double(item.quantity) ?? 0
       return runningTotal + (taxPrice * quantity)
     }
@@ -358,8 +358,8 @@ class CheckoutViewController: UIViewController, AddItemViewControllerDelegate {
 
   func getTotal() -> String {
     let total = items.reduce(0) { (runningTotal, item) -> Double in
-      let unitPrice = Double(item.unitAmount.value) ?? 0
-      let taxPrice = Double(item.tax!.value) ?? 0
+      let unitPrice = Double(item.unitAmount.value ?? "0") ?? 0
+      let taxPrice = Double(item.tax?.value ?? "0") ?? 0
       let quantity = Double(item.quantity) ?? 0
       return runningTotal + ((unitPrice * quantity) + (taxPrice * quantity))
     }

--- a/Samples.Swift/Samples.Swift/ViewControllers/CheckoutViewController/Views/ItemCell.swift
+++ b/Samples.Swift/Samples.Swift/ViewControllers/CheckoutViewController/Views/ItemCell.swift
@@ -49,7 +49,7 @@ class ItemCell: UITableViewCell {
 
     priceLabel.textColor = .black
     priceLabel.font = .systemFont(ofSize: 12)
-    priceLabel.text = "Price: \(item.unitAmount.value.convertDoubleToCurrency(withQuantity: item.quantity) ?? "")"
+    priceLabel.text = "Price: \(item.unitAmount.value?.convertDoubleToCurrency(withQuantity: item.quantity) ?? "")"
     priceLabel.sizeToFit()
 
     taxLabel.textColor = .black


### PR DESCRIPTION
This bumps the Cocoapods and Carthage version to the latest version `0.55.0`. There were also a few places to update force unwrapping as well as add an optional to the unit amount value due to updates in the SDK.