### PR TITLE
Bump Version to 0.77.0

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-binary "https://github.com/paypal/paypalcheckout-ios/raw/main/Carthage/PayPalCheckout.json" ~> 0.70.0
+binary "https://github.com/paypal/paypalcheckout-ios/raw/main/Carthage/PayPalCheckout.json" ~> 0.77.0

--- a/Podfile
+++ b/Podfile
@@ -2,7 +2,7 @@ workspace 'Samples.xcworkspace'
 use_frameworks!
 
 def dependency
-  pod 'PayPalCheckout', '0.70.0'
+  pod 'PayPalCheckout', '0.77.0'
 end
 
 target 'Samples.ObjC' do


### PR DESCRIPTION
Bump PayPalCheckout for Carthage and CocoaPods to version 0.77.0

