### PR TITLE
Bumping NXO version to 0.102.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,7 +54,6 @@ playground.xcworkspace
 # you should judge for yourself, the pros and cons are mentioned at:
 # https://guides.cocoapods.org/using/using-cocoapods.html#should-i-check-the-pods-directory-into-source-control
 Pods/
-Podfile.lock
 
 # Add this line if you want to avoid checking in source code from the Xcode workspace
 *.xcworkspace
@@ -65,7 +64,6 @@ Podfile.lock
 Carthage/
 Carthage/Checkouts
 Carthage/Build/
-Cartfile.resolved
 
 # Accio dependency management
 Dependencies/

--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-binary "https://github.com/paypal/paypalcheckout-ios/raw/main/Carthage/PayPalCheckout.json" ~> 0.77.0
+binary "https://github.com/paypal/paypalcheckout-ios/raw/main/Carthage/PayPalCheckout.json" ~> 0.102.0

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,0 +1,1 @@
+binary "https://github.com/paypal/paypalcheckout-ios/raw/main/Carthage/PayPalCheckout.json" "0.102.0"

--- a/Podfile
+++ b/Podfile
@@ -2,7 +2,7 @@ workspace 'Samples.xcworkspace'
 use_frameworks!
 
 def dependency
-  pod 'PayPalCheckout', '0.77.0'
+  pod 'PayPalCheckout', '0.102.0'
 end
 
 target 'Samples.ObjC' do

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,0 +1,16 @@
+PODS:
+  - PayPalCheckout (0.102.0)
+
+DEPENDENCIES:
+  - PayPalCheckout (= 0.102.0)
+
+SPEC REPOS:
+  trunk:
+    - PayPalCheckout
+
+SPEC CHECKSUMS:
+  PayPalCheckout: a21efb01d9099c999491d6e8cb51f575b3045622
+
+PODFILE CHECKSUM: b8144a085c7b682d240969e499af05ffae0b8394
+
+COCOAPODS: 1.10.1

--- a/Samples.Objc/Samples.ObjC.xcodeproj/project.pbxproj
+++ b/Samples.Objc/Samples.ObjC.xcodeproj/project.pbxproj
@@ -43,6 +43,7 @@
 		06936E09260A7F330099E314 /* SceneDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 06936DE6260A7F330099E314 /* SceneDelegate.m */; };
 		06D715F426127D0400B611B7 /* PayPalCheckout.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 06936DB4260A7DC80099E314 /* PayPalCheckout.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
 		06FFBAA7261E0617003FC893 /* UIViewController+Extension.m in Sources */ = {isa = PBXBuildFile; fileRef = 06FFBAA6261E0617003FC893 /* UIViewController+Extension.m */; };
+		0E1C1503DEB27C593EA7300D /* Pods_Samples_ObjC.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7A98366E2711E6EFD1FF4FF7 /* Pods_Samples_ObjC.framework */; };
 		117AAAC92479FDBA00A63B34 /* PayPalAPI.m in Sources */ = {isa = PBXBuildFile; fileRef = 117AAAC82479FDBA00A63B34 /* PayPalAPI.m */; };
 		117AAAF1247A007800A63B34 /* PayPalAPI.h in Headers */ = {isa = PBXBuildFile; fileRef = 117AAAC72479FDBA00A63B34 /* PayPalAPI.h */; };
 /* End PBXBuildFile section */
@@ -89,6 +90,9 @@
 		117AAA7A2479FAE600A63B34 /* Samples.ObjC.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Samples.ObjC.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		117AAAC72479FDBA00A63B34 /* PayPalAPI.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PayPalAPI.h; sourceTree = "<group>"; };
 		117AAAC82479FDBA00A63B34 /* PayPalAPI.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = PayPalAPI.m; sourceTree = "<group>"; };
+		7A98366E2711E6EFD1FF4FF7 /* Pods_Samples_ObjC.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Samples_ObjC.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		C249445652090065B9E20AAE /* Pods-Samples.ObjC.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Samples.ObjC.release.xcconfig"; path = "Target Support Files/Pods-Samples.ObjC/Pods-Samples.ObjC.release.xcconfig"; sourceTree = "<group>"; };
+		E0658D1D07E3951457E0265D /* Pods-Samples.ObjC.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Samples.ObjC.debug.xcconfig"; path = "Target Support Files/Pods-Samples.ObjC/Pods-Samples.ObjC.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -97,6 +101,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				06D715F426127D0400B611B7 /* PayPalCheckout.framework in Frameworks */,
+				0E1C1503DEB27C593EA7300D /* Pods_Samples_ObjC.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -107,6 +112,7 @@
 			isa = PBXGroup;
 			children = (
 				06936DB4260A7DC80099E314 /* PayPalCheckout.framework */,
+				7A98366E2711E6EFD1FF4FF7 /* Pods_Samples_ObjC.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -224,6 +230,7 @@
 				117AAA7C2479FAE600A63B34 /* Samples.ObjC */,
 				117AAA7B2479FAE600A63B34 /* Products */,
 				06936DB3260A7DC80099E314 /* Frameworks */,
+				4C2174950CA63A176451E57B /* Pods */,
 			);
 			sourceTree = "<group>";
 		};
@@ -252,6 +259,16 @@
 				06936DE6260A7F330099E314 /* SceneDelegate.m */,
 			);
 			path = Samples.ObjC;
+			sourceTree = "<group>";
+		};
+		4C2174950CA63A176451E57B /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				E0658D1D07E3951457E0265D /* Pods-Samples.ObjC.debug.xcconfig */,
+				C249445652090065B9E20AAE /* Pods-Samples.ObjC.release.xcconfig */,
+			);
+			name = Pods;
+			path = ../Pods;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -287,11 +304,13 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 117AAA932479FAE700A63B34 /* Build configuration list for PBXNativeTarget "Samples.ObjC" */;
 			buildPhases = (
+				916491FC13A06BD04B1C0CB7 /* [CP] Check Pods Manifest.lock */,
 				117AAAEC247A002600A63B34 /* Headers */,
 				117AAA762479FAE600A63B34 /* Sources */,
 				117AAA772479FAE600A63B34 /* Frameworks */,
 				117AAA782479FAE600A63B34 /* Resources */,
 				062A4F3C26251B690071FEAE /* ShellScript */,
+				BCAADAD28F21D89142113577 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -366,6 +385,45 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "if [ -d $SRCROOT/../Pods ]; then \n  echo \"💫 Pods folder exists so skipping carthage copy...\"\nelse \n  if [ -d $SRCROOT/../Carthage ]; then \n    echo \"💫 Carthage folder exists, now copying frameworks...\"\n    /usr/local/bin/carthage copy-frameworks\n  else \n    echo \"❌ Carthage folder does not exist, did you run carthage update?\"\n  fi\nfi\n";
+		};
+		916491FC13A06BD04B1C0CB7 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-Samples.ObjC-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		BCAADAD28F21D89142113577 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Samples.ObjC/Pods-Samples.ObjC-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Samples.ObjC/Pods-Samples.ObjC-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Samples.ObjC/Pods-Samples.ObjC-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -512,6 +570,7 @@
 		};
 		117AAA942479FAE700A63B34 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = E0658D1D07E3951457E0265D /* Pods-Samples.ObjC.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "Apple Development";
@@ -535,6 +594,7 @@
 		};
 		117AAA952479FAE700A63B34 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = C249445652090065B9E20AAE /* Pods-Samples.ObjC.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "Apple Development";

--- a/Samples.Objc/Samples.ObjC/API/PayPalAPI.h
+++ b/Samples.Objc/Samples.ObjC/API/PayPalAPI.h
@@ -22,7 +22,6 @@ NS_ASSUME_NONNULL_BEGIN
 @interface PayPalAPI : NSObject
 
 @property NSString *clientId;
-@property NSString *returnUrl;
 @property NSString *nodeAppBaseURL;
 @property NSString *baseURLv2;
 @property NSString * _Nullable accessToken;

--- a/Samples.Objc/Samples.ObjC/API/PayPalAPI.m
+++ b/Samples.Objc/Samples.ObjC/API/PayPalAPI.m
@@ -34,7 +34,6 @@
 - (id)init {
   if (self = [super init]) {
     self.clientId = @"<client_id>";
-    self.returnUrl = @"<return_url>";
     self.nodeAppBaseURL = @"http://localhost:3000/";
     self.baseURLv2 = @"https://api.sandbox.paypal.com/v2/";
     self.accessTokenEndpoint = [[FetchAccessTokenEndpoint alloc] init];

--- a/Samples.Objc/Samples.ObjC/AppDelegate.m
+++ b/Samples.Objc/Samples.ObjC/AppDelegate.m
@@ -17,12 +17,12 @@
 
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
-  PPCheckoutConfig *config = [[PPCheckoutConfig alloc] initWithClientID:[PayPalAPI.shared clientId]
-                                                              returnUrl:[PayPalAPI.shared returnUrl]
-                                                            createOrder:nil
-                                                              onApprove:nil
-                                                               onCancel:nil
-                                                                onError:nil
+  PPCheckoutConfig *config = [[PPCheckoutConfig alloc] initWithClientID: [PayPalAPI.shared clientId]
+                                                            createOrder: nil
+                                                              onApprove: nil
+                                                       onShippingChange: nil
+                                                               onCancel: nil
+                                                                onError: nil
                                                             environment:PPCEnvironmentSandbox];
   [PPCheckout setConfig:config];
   return YES;

--- a/Samples.Objc/Samples.ObjC/ViewControllers/CheckoutViewController/CheckoutViewController.m
+++ b/Samples.Objc/Samples.ObjC/ViewControllers/CheckoutViewController/CheckoutViewController.m
@@ -61,6 +61,7 @@
   onApprove:^(PPCApproval *approval) {
     [self onApproveCallbackWithApproval:approval];
   }
+  onShippingChange: nil
   onCancel:^{
     [self onCancelCallback];
   }
@@ -104,6 +105,7 @@
 
   PPCOrderRequest *order = [[PPCOrderRequest alloc] initWithIntent:PPCOrderIntentAuthorize
                                                      purchaseUnits:@[purchaseUnit]
+                                             processingInstruction:PPCOrderProcessingInstructionNone
                                                              payer:nil
                                                 applicationContext:nil];
   return order;
@@ -150,7 +152,7 @@
 
 /// onApprove callback: This will be called when checkout with PayPalCheckout is completed, you will need to handle authorizing or capturing the funds in this callback
 - (void)onApproveCallbackWithApproval:(PPCApproval *)approval {
-  if ([approval.data.intent isEqualToString:@"AUTHORIZE"]) {
+  if (approval.data.intent == PPCOrderIntentAuthorize) {
     [approval.actions authorizeOnComplete:^(PPCAuthorizeActionSuccess *success, NSError *error) {
       if (error) {
         NSLog(@"Fail to authorize order with error %@", error.localizedDescription);
@@ -160,7 +162,7 @@
         NSLog(@"Authorize order: No error and no success response");
       }
     }];
-  } else if ([approval.data.intent isEqualToString:@"CAPTURE"] || [approval.data.intent isEqualToString:@"SALE"]) {
+  } else if (approval.data.intent == PPCOrderIntentCapture) {
     [approval.actions captureOnComplete:^(PPCCaptureActionSuccess *success, NSError *error) {
       if (error) {
         NSLog(@"Fail to capture order with error %@", error.localizedDescription);

--- a/Samples.Swift/Samples.Swift.xcodeproj/project.pbxproj
+++ b/Samples.Swift/Samples.Swift.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		117AAAAC2479FB4900A63B34 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 117AAAAB2479FB4900A63B34 /* Assets.xcassets */; };
 		117AAAAF2479FB4900A63B34 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 117AAAAD2479FB4900A63B34 /* LaunchScreen.storyboard */; };
+		525EE2164A8CB24C5648F50A /* Pods_Samples_Swift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AD6B1120915B7791697EEB25 /* Pods_Samples_Swift.framework */; };
 		BE21914A260CF5BA00ECE484 /* String+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE219149260CF5BA00ECE484 /* String+Extensions.swift */; };
 		BE435C49261F3EA800E17CA6 /* UITextField+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE435C48261F3EA800E17CA6 /* UITextField+Extensions.swift */; };
 		BE435D472625E9FB00E17CA6 /* PayPalCheckout.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 06936DB8260A7DD50099E314 /* PayPalCheckout.framework */; };
@@ -33,6 +34,9 @@
 		117AAAAB2479FB4900A63B34 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		117AAAAE2479FB4900A63B34 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		117AAAB02479FB4900A63B34 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		3537B4AE9E2C47DA2F8224FE /* Pods-Samples.Swift.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Samples.Swift.release.xcconfig"; path = "Target Support Files/Pods-Samples.Swift/Pods-Samples.Swift.release.xcconfig"; sourceTree = "<group>"; };
+		5D8B27F893685DEC7D3FB134 /* Pods-Samples.Swift.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Samples.Swift.debug.xcconfig"; path = "Target Support Files/Pods-Samples.Swift/Pods-Samples.Swift.debug.xcconfig"; sourceTree = "<group>"; };
+		AD6B1120915B7791697EEB25 /* Pods_Samples_Swift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Samples_Swift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		BE219149260CF5BA00ECE484 /* String+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Extensions.swift"; sourceTree = "<group>"; };
 		BE435C48261F3EA800E17CA6 /* UITextField+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITextField+Extensions.swift"; sourceTree = "<group>"; };
 		BE7CF046260B7B6500288176 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -56,6 +60,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				BE435D472625E9FB00E17CA6 /* PayPalCheckout.framework in Frameworks */,
+				525EE2164A8CB24C5648F50A /* Pods_Samples_Swift.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -66,6 +71,7 @@
 			isa = PBXGroup;
 			children = (
 				06936DB8260A7DD50099E314 /* PayPalCheckout.framework */,
+				AD6B1120915B7791697EEB25 /* Pods_Samples_Swift.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -76,6 +82,7 @@
 				117AAAA12479FB4900A63B34 /* Samples.Swift */,
 				117AAAA02479FB4900A63B34 /* Products */,
 				06936DB7260A7DD50099E314 /* Frameworks */,
+				D3DB692AE264675512ECB149 /* Pods */,
 			);
 			sourceTree = "<group>";
 		};
@@ -184,6 +191,16 @@
 			path = AddItemViewConroller;
 			sourceTree = "<group>";
 		};
+		D3DB692AE264675512ECB149 /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				5D8B27F893685DEC7D3FB134 /* Pods-Samples.Swift.debug.xcconfig */,
+				3537B4AE9E2C47DA2F8224FE /* Pods-Samples.Swift.release.xcconfig */,
+			);
+			name = Pods;
+			path = ../Pods;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -191,10 +208,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 117AAAB32479FB4900A63B34 /* Build configuration list for PBXNativeTarget "Samples.Swift" */;
 			buildPhases = (
+				ED6A0712C75A5848F94A43BE /* [CP] Check Pods Manifest.lock */,
 				117AAA9B2479FB4900A63B34 /* Sources */,
 				117AAA9C2479FB4900A63B34 /* Frameworks */,
 				117AAA9D2479FB4900A63B34 /* Resources */,
 				062A4F3E26251CC60071FEAE /* ShellScript */,
+				D361397347421ED6D132D9FB /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -269,6 +288,45 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "if [ -d $SRCROOT/../Pods ]; then \n  echo \"💫 Pods folder exists so skipping carthage copy...\"\nelse \n  if [ -d $SRCROOT/../Carthage ]; then \n    echo \"💫 Carthage folder exists, now copying frameworks...\"\n    /usr/local/bin/carthage copy-frameworks\n  else \n    echo \"❌ Carthage folder does not exist, did you run carthage update?\"\n  fi\nfi\n";
+		};
+		D361397347421ED6D132D9FB /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Samples.Swift/Pods-Samples.Swift-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Samples.Swift/Pods-Samples.Swift-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Samples.Swift/Pods-Samples.Swift-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		ED6A0712C75A5848F94A43BE /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-Samples.Swift-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -427,6 +485,7 @@
 		};
 		117AAAB42479FB4900A63B34 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 5D8B27F893685DEC7D3FB134 /* Pods-Samples.Swift.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "Apple Development";
@@ -453,6 +512,7 @@
 		};
 		117AAAB52479FB4900A63B34 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 3537B4AE9E2C47DA2F8224FE /* Pods-Samples.Swift.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "Apple Development";

--- a/Samples.Swift/Samples.Swift/API/PayPal.API.swift
+++ b/Samples.Swift/Samples.Swift/API/PayPal.API.swift
@@ -27,7 +27,6 @@ class PayPal {
 
   // MARK: - Attributes
   static let clientId: String = "<client_id>"
-  static let returnUrl: String = "<return_url>"
   private static let nodeAppBaseURL: String = "http://localhost:3000/"
   private static let baseURLv2: String = "https://api.sandbox.paypal.com/v2/"
 

--- a/Samples.Swift/Samples.Swift/AppDelegate.swift
+++ b/Samples.Swift/Samples.Swift/AppDelegate.swift
@@ -30,7 +30,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
   func setConfig() {
     let config = CheckoutConfig(
       clientID: PayPal.clientId,
-      returnUrl: PayPal.returnUrl,
       environment: .sandbox
     )
 

--- a/Samples.Swift/Samples.Swift/ViewControllers/CheckoutViewController/CheckoutViewController.swift
+++ b/Samples.Swift/Samples.Swift/ViewControllers/CheckoutViewController/CheckoutViewController.swift
@@ -283,7 +283,7 @@ class CheckoutViewController: UIViewController, AddItemViewControllerDelegate {
 
   private func processOrderActions(with approval: Approval) {
     switch approval.data.intent {
-    case "AUTHORIZE":
+    case .authorize:
       approval.actions.authorize { success, error in
         if let error = error {
           self.errorResultAction(errorMessage: error.localizedDescription)
@@ -296,7 +296,7 @@ class CheckoutViewController: UIViewController, AddItemViewControllerDelegate {
         }
       }
 
-    case "CAPTURE", "SALE":
+    case .capture:
       approval.actions.capture { success, error in
         if let error = error {
           self.errorResultAction(errorMessage: error.localizedDescription)

--- a/Samples.xcworkspace/contents.xcworkspacedata
+++ b/Samples.xcworkspace/contents.xcworkspacedata
@@ -7,4 +7,7 @@
    <FileRef
       location = "group:Samples.Swift/Samples.Swift.xcodeproj">
    </FileRef>
+   <FileRef
+      location = "group:Pods/Pods.xcodeproj">
+   </FileRef>
 </Workspace>

--- a/bin/setids
+++ b/bin/setids
@@ -3,7 +3,6 @@
 # If they give us the input on the command line use it
 clientId="${1-}"
 clientSecret="${2-}"
-returnUrl="${3-}"
 
 ## Gather our input
 
@@ -21,23 +20,12 @@ fi
 # Read client secret if provided
 if [[ "${clientSecret}" = "" ]]; then
   printf "Please enter your \x1b[1mclient secret\x1b[0m: "
-  read clientSecret 
+  read clientSecret
 
   if [[ "${clientSecret}" = "" ]]; then
     printf "\nCanceling; we need a CLIENT_SECRET from you"
     exit 1
   fi
-fi
-
-# Read return url if provided 
-if [[ "${returnUrl}" = "" ]]; then 
-  printf "Please enter your \x1b[1mclient return url\x1b[0m: "
-  read returnUrl
-
-  if [[ "${returnUrl}" = "" ]]; then 
-    printf "\nCanceling; we need a return_url from you"
-    exit 1
-  fi 
 fi
 
 # Create a functions for easy reuse of status
@@ -46,13 +34,13 @@ function STATUS() {
 }
 
 # Check to see if we have enough parameters
-if [[ "${clientId}" = "" ]] || [[ "${clientSecret}" = "" ]] || [[ "${returnUrl}" = "" ]]; then
-  printf "Usage: setids <client_id> <client_secret> <return_url>\n"
+if [[ "${clientId}" = "" ]] || [[ "${clientSecret}" = "" ]]; then
+  printf "Usage: setids <client_id> <client_secret>\n"
   exit 1
 fi
 
 # Let's get started
-printf "\nChecking for places where your client ids, secrets, and return url are used\n\n"
+printf "\nChecking for places where your client ids and secrets are used\n\n"
 
 # Check to see if have a .env file and if not, create one
 printf "[    ] Check for an existing .env file"
@@ -72,15 +60,5 @@ find . -name "*.m" -print0 | eval $sedString
 STATUS 32 done
 
 printf "[    ] Updating swift files for CLIENT_ID..."
-find . -name "*.swift" -print0 | eval $sedString
-STATUS 32 done
-
-sedString=$(echo "xargs -0 sed -i '' 's,<return_url>,${returnUrl},g'")
-
-printf "[    ] Updating objective-c files for return_url..."
-find . -name "*.m" -print0 | eval $sedString
-STATUS 32 done 
-
-printf "[    ] Updating swift files for return_url..."
 find . -name "*.swift" -print0 | eval $sedString
 STATUS 32 done

--- a/node_checkout/index.js
+++ b/node_checkout/index.js
@@ -17,8 +17,9 @@ const authUrl = "https://api.sandbox.paypal.com/v1/oauth2/token";
 
 app.post("/auth/token", (req, res) => {
   let body = req.body;
-  if ("clientId" in body && body.clientId == process.env.CLIENT_ID) {
-    const authString = `${process.env.CLIENT_ID}:${process.env.CLIENT_SECRET}`;
+
+  if (body.clientId) {
+    const authString = `${body.clientId}:`;
     const buffer = Buffer.from(`${authString}`);
     const base64EncodedString = buffer.toString('base64');
     const headers = {
@@ -43,19 +44,19 @@ app.post("/auth/token", (req, res) => {
               { colors: true }
             )
 
-            console.error(`${red('Error fetching token:')}: ${message}`)            
+            console.error(`${red('Error fetching token:')}: ${message}`)
             res.status(400).send(value.error_description);
           }
           else {
             let message = inspect(value, { colors: true })
 
-            console.error(`${green('Successful token fetch')}: ${message}`)            
+            console.error(`${green('Successful token fetch')}: ${message}`)
             res.status(200).send(value);
           }
         })
         .catch(error => {
           let message = inspect(error, { colors: true })
-        
+
           console.error(`${red('Error receiving response')}: ${message}`)
           res.status(400).send(error);
         })


### PR DESCRIPTION
This PR updates both the swift and objc sample apps for the newest release of the Native Checkout SDK. Also included is some updates to the `setids` and listener scripts to remove unnecessary checks